### PR TITLE
Add support for Visual Studio's 'metrics.exe'

### DIFF
--- a/Source/ReSharperReports/Program.cs
+++ b/Source/ReSharperReports/Program.cs
@@ -73,6 +73,9 @@ namespace ReSharperReports
                 case "Report":
                     xslFileName = "ReSharperReports.inspectcode.xsl";
                     break;
+                case "CodeMetricsReport":
+                    xslFileName = "ReSharperReports.metrics.xsl";
+                    break;
                 default:
                     Logger.WriteError("Unable to parse input XML file.");
                     break;

--- a/Source/ReSharperReports/ReSharperReports.csproj
+++ b/Source/ReSharperReports/ReSharperReports.csproj
@@ -70,6 +70,7 @@
   <ItemGroup>
     <EmbeddedResource Include="dupfinder.xsl" />
     <EmbeddedResource Include="inspectcode.xsl" />
+    <EmbeddedResource Include="metrics.xsl" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="FodyWeavers.xml" />

--- a/Source/ReSharperReports/metrics.xsl
+++ b/Source/ReSharperReports/metrics.xsl
@@ -57,14 +57,14 @@
   <xsl:template match="Namespaces">
     <h3>Details</h3>
     <table>
-      <tr  class="details">
-      <th>Namespace</th>
+      <tr class="details">
+        <th>Namespace</th>
         <th>MaintainabilityIndex</th>
         <th>CyclomaticComplexity</th>
         <th>ClassCoupling</th>
         <th>DepthOfInheritance</th>
         <th>LinesOfCode</th>
-    </tr>
+      </tr>
       <xsl:apply-templates select="Namespace" />
     </table>
   </xsl:template>

--- a/Source/ReSharperReports/metrics.xsl
+++ b/Source/ReSharperReports/metrics.xsl
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="html" encoding="utf-8" indent="yes" />
+
+  <xsl:template match="/">
+    <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
+
+    <html>
+      <head>
+        <title>Metrics Report</title>
+        <style>
+          tr.summary {
+            background-color: #B1D1F9;
+          }
+
+          tr.details {
+            background-color: #B2F7C0;
+          }
+
+          table, th, td {
+            border: 1px solid black;
+            border-collapse: collapse;
+          }
+
+          th, td {
+            padding: 5px;
+            text-align: left;
+          }
+        </style>
+      </head>
+      <body>
+        <h1>Metrics Report</h1>
+        <xsl:apply-templates select="CodeMetricsReport/Targets/Target/Modules/Module" />
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="Module">
+    <h2><xsl:apply-templates select="@Name" /></h2>
+    <h3>Summary</h3>
+    <table>
+      <tr class="summary">
+        <th>MaintainabilityIndex</th>
+        <th>CyclomaticComplexity</th>
+        <th>ClassCoupling</th>
+        <th>DepthOfInheritance</th>
+        <th>LinesOfCode</th>
+      </tr>
+      <tr>
+        <xsl:apply-templates select="Metrics/Metric" />
+      </tr>
+    </table>
+
+    <xsl:apply-templates select="Namespaces" />
+  </xsl:template>
+
+  <xsl:template match="Namespaces">
+    <h3>Details</h3>
+    <table>
+      <tr  class="details">
+      <th>Namespace</th>
+        <th>MaintainabilityIndex</th>
+        <th>CyclomaticComplexity</th>
+        <th>ClassCoupling</th>
+        <th>DepthOfInheritance</th>
+        <th>LinesOfCode</th>
+    </tr>
+      <xsl:apply-templates select="Namespace" />
+    </table>
+  </xsl:template>
+
+  <xsl:template match="Namespace">
+    <tr>
+      <td><xsl:apply-templates select="@Name" /></td>
+      <xsl:apply-templates select="Metrics/Metric" />
+    </tr>
+  </xsl:template>
+
+  <xsl:template match="Metrics/Metric">
+    <td>
+      <xsl:apply-templates select="@Value" />
+    </td>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
We could add support for Visual Studio's standalone tool [metrics.exe](https://blogs.msdn.microsoft.com/camerons/2011/01/28/code-metrics-from-the-command-line/) as it behaves very similar to `dupfinder.exe` and `inspectcode.exe`: All three tools create xml files which we can parse into html. I am thinking about creating a Cake Addin for `metrics.exe` in the future as I have not found one yet.

The style of the included `metrics.xsl` file is based on `inspectcode.xsl`. You can find an example [here](https://gist.github.com/fwinkelbauer/58be7e7bb479254e903553f7c109d508).

I am fully aware that this is a longshot: The content of this pull requests is not consistent with the project name, but it fits with the overall purpose (parsing xml generated by analytical tools).